### PR TITLE
aiohttp: Add helper for deprecating handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install with `pip install kiwi-platform`.
 
 ## Documentation
 
-[kiwi-platform-py.readthedocs.io](https://kiwi-platform-py.readthedocs.io/en/latest/)
+Check the documentation on [reathedocs.io](https://kiwi-platform-py.readthedocs.io/en/latest/).
 
 ## Contributing
 

--- a/docs/aiohttp.rst
+++ b/docs/aiohttp.rst
@@ -8,3 +8,6 @@
 
     .. automodule:: kw.platform.aiohttp.session
         :members:
+
+    .. automodule:: kw.platform.aiohttp.utils
+        :members:

--- a/kw/platform/aiohttp/__init__.py
+++ b/kw/platform/aiohttp/__init__.py
@@ -6,11 +6,12 @@ Extensions and helpers for building AIOHTTP-based applications.
 """
 
 from ..utils import ensure_module_is_available
-from .middlewares import user_agent_middleware
 
 
 required_module = "aiohttp"
 if ensure_module_is_available(required_module):
+    from . import utils
+    from .middlewares import user_agent_middleware
     from .monkey import construct_user_agent, patch, patch_with_user_agent
     from .session import KiwiClientSession
 
@@ -20,6 +21,7 @@ if ensure_module_is_available(required_module):
         "construct_user_agent",
         "patch_with_user_agent",
         "patch",
+        "utils",
     ]
 else:
     from .._compat import ModuleNotFoundError  # pylint: disable=redefined-builtin

--- a/kw/platform/aiohttp/utils.py
+++ b/kw/platform/aiohttp/utils.py
@@ -1,0 +1,63 @@
+"""
+Helpers and Utils
+=================
+"""
+
+from functools import wraps
+
+from ..utils import httpdate
+
+
+def set_sunset(response, when=None, info_url=None):
+    """Update aiohttp response object with the ``Sunset`` HTTP header.
+
+    :param response: Response object to update.
+    :type response: :class:`aiohttp.web.Response`
+    :param when: When the Sunset date arrives, must be UTC.
+    :type when: datetime
+    :param info_url: URL to a page with more information about the Sunset.
+    :type info_url: str
+    :rtype: :class:`aiohttp.web.Response`
+    """
+    if info_url:
+        link = '<{}>;rel="sunset"'.format(info_url)
+        response.headers["Link"] = (
+            "{},{}".format(response.headers["Link"], link)
+            if response.headers.get("Link")
+            else link
+        )
+    if when:
+        response.headers["Sunset"] = httpdate(when)
+
+    return response
+
+
+def sunset(when=None, info_url=None):
+    """A decorator for deprecating views by setting the ``Sunset`` HTTP header.
+
+    Read about the ``Sunset`` header in
+    `rfc8594 <https://tools.ietf.org/html/rfc8594>`_.
+
+    Usage::
+
+        @sunset(when=datetime(2019, 8, 1, 10, 0, 0))
+        async def index(request):
+            return web.Response("Hello, world!")
+
+    :param when: When the Sunset date arrives, must be UTC.
+    :type when: datetime
+    :param info_url: URL to a page with more information about the Sunset.
+    :type info_url: str
+    """
+    if when is None and info_url is None:
+        raise TypeError("function takes at least one argument (0 given)")
+
+    def wrapper(view):
+        @wraps(view)
+        async def sunset_view(*args, **kwargs):
+            response = await view(*args, **kwargs)
+            return set_sunset(response, when=when, info_url=info_url)
+
+        return sunset_view
+
+    return wrapper

--- a/kw/platform/utils.py
+++ b/kw/platform/utils.py
@@ -98,3 +98,33 @@ def _add_user_agent(user_agent=None):
         return func(*args, **kwargs)
 
     return _add_headers
+
+
+def httpdate(dt):
+    """Return a string representation of a date according to RFC 1123 (HTTP/1.1).
+
+    The supplied date must be in UTC.
+
+    :param dt: Datetime object in UTC.
+    :type dt: datetime
+    :rtype: str
+    """
+    weekday = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"][dt.weekday()]
+    month = [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+    ][dt.month - 1]
+    return (
+        "{weekday}, {dt.day:02d} {month} {dt.year:04d} "
+        "{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d} GMT"
+    ).format(weekday=weekday, month=month, dt=dt)

--- a/kw/platform/wsgi.py
+++ b/kw/platform/wsgi.py
@@ -1,6 +1,6 @@
 """
-WSGI helpers
-============
+WSGI
+====
 
 Various helpers for WSGI applications.
 """


### PR DESCRIPTION
- Fix https://github.com/kiwicom/kiwi-platform-py/issues/9

I was trying to use `email.utils.formatdate` to format date according to RFC 1123, the problem is that no matter what I do, the function shifts the date by two hours (even if I pass a datetime with `tzinfo=timezone.utc`, it's just ignored). So we would probably end up using something like pytz, which seems like an unnecessary dependency. If someone has a good understanding how datetime with tzinfo in python works, feel free to help out here :-)