### PR TITLE
Add missing `.gitignore` patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,64 @@ env
 .cache
 .mypy_cache
 .python-version
+
+# Distribution / packaging
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+MANIFEST
+
+# Unit test / coverage reports
+.nox/
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Django stuff:
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.venv
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/


### PR DESCRIPTION
Some patterns are missing in your `.gitignore` file, consider adding them so that
Git ignores them:

```
### PYTHON

# Distribution / packaging
wheels/
pip-wheel-metadata/
share/python-wheels/
MANIFEST

# Unit test / coverage reports
.nox/
*.cover
.hypothesis/
.pytest_cache/

# Django stuff:
local_settings.py
db.sqlite3

# Flask stuff:
instance/
.webassets-cache

# Scrapy stuff:
.scrapy

# Jupyter Notebook
.ipynb_checkpoints

# IPython
profile_default/
ipython_config.py

# celery beat schedule file
celerybeat-schedule

# SageMath parsed files
*.sage.py

# Environments
.venv
venv/
ENV/
env.bak/
venv.bak/

# Spyder project settings
.spyderproject
.spyproject

# Rope project settings
.ropeproject

# mkdocs documentation
/site

# mypy
.mypy_cache/
.dmypy.json
dmypy.json

# Pyre type checker
.pyre/
```


---

*via The Zoo*